### PR TITLE
 fix(deps): genfun@5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/zkat/protoduck#readme",
   "dependencies": {
-    "genfun": "^4.0.1"
+    "genfun": "^5.0.0"
   },
   "devDependencies": {
     "mocha": "^3.2.0",


### PR DESCRIPTION
This synchronizes the licensing changes for the packages to MIT as well as the node version support.

Version 4 of genfun uses the `CC0-1.0` license which is preventing the [Angular CLI](https://github.com/angular/angular-cli) from using `pacote`.

/cc @zkat 